### PR TITLE
Fix asset path for subdirectory deployments

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: './',
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
## Summary
- set the Vite base path to `./` so built assets load correctly when the app is deployed from a subdirectory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0ec2a5c14832095400b2e20bedca9